### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,29 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyterlab/maintainer-tools/compare/v0.1.0...ff4a0e69b16c45d8c48ff0862a501b0b57d5e91f))
+
+### Enhancements made
+
+- Add base setup action [#12](https://github.com/jupyterlab/maintainer-tools/pull/12) ([@blink1073](https://github.com/blink1073))
+- Add label enforcer [#11](https://github.com/jupyterlab/maintainer-tools/pull/11) ([@blink1073](https://github.com/blink1073))
+- Use releaser [#7](https://github.com/jupyterlab/maintainer-tools/pull/7) ([@blink1073](https://github.com/blink1073))
+- Add a PR Script Workflow [#1](https://github.com/jupyterlab/maintainer-tools/pull/1) ([@blink1073](https://github.com/blink1073))
+
+### Other merged PRs
+
+- Add support for custom commit messages [#9](https://github.com/jupyterlab/maintainer-tools/pull/9) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/maintainer-tools/graphs/contributors?from=2021-11-17&to=2021-11-18&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fmaintainer-tools+involves%3Ablink1073+updated%3A2021-11-17..2021-11-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fmaintainer-tools+involves%3Ajtpio+updated%3A2021-11-17..2021-11-18&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fmaintainer-tools+involves%3Awelcome+updated%3A2021-11-17..2021-11-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0
 
 Add a PR Script Workflow by @blink1073 [#1](https://github.com/jupyterlab/maintainer-tools/pull/1)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/maintainer-tools  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.0 |