### PR TITLE
Sleep for 60 seconds on PR open in Label Enforcer

### DIFF
--- a/.github/actions/enforce-label/action.yml
+++ b/.github/actions/enforce-label/action.yml
@@ -3,6 +3,10 @@ description: "Enforce assigning triage labels before merging PRs"
 runs:
   using: "composite"
   steps:
+    - name: sleep-if-needed
+      shell: bash
+      if: ${{ github.event.action == 'opened' }}
+      run: sleep 60
     - name: enforce-triage-labels
       uses: yogevbd/enforce-label-action@2.1.0
       with:


### PR DESCRIPTION
Give time for maintainer to select a label or for a labeler workflow to run