### PR TITLE
Add downstream tester

### DIFF
--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -22,5 +22,5 @@ runs:
           ./test/bin/python -m pip install -U pip
           ./test/bin/python -m pip install ${package_spec}
           ./test/bin/python -m pip install . --force-reinstall
-          ${{ input.env_values }} ./test/bin/pytest ${pytest_args}
+          ${{ input.env_values }}; ./test/bin/pytest ${pytest_args}
           rm -rf ./test

--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -16,11 +16,24 @@ runs:
     - name: set up venv
       shell: bash
       run: |
-          package_spec=${${{input.package_spec}}:-"${{inputs.package_name}}[test]"}
-          pytest_args=${${{input.pytest_args}}:-"--pyargs ${{inputs.package_name}}"}
-          python -m venv test
-          ./test/bin/python -m pip install -U pip
-          ./test/bin/python -m pip install ${package_spec}
-          ./test/bin/python -m pip install . --force-reinstall
-          ${{ input.env_values }}; ./test/bin/pytest ${pytest_args}
-          rm -rf ./test
+          set -x
+          # Set up env values
+          package_spec="${{inputs.package_spec}}"
+          package_spec=${package_spec:-"${{inputs.package_name}}[test]"}
+          pytest_args="${{inputs.pytest_args}}"
+          pytest_args=${pytest_args:-"--pyargs ${{inputs.package_name}}"}
+          eval "${{inputs.env_values}}"
+
+          # Set up venv
+          python -m venv test_venv
+          export PATH=$(pwd)/test_venv/bin:$PATH
+          python -m pip install -U pip
+          python -m pip install ${package_spec}
+          python -m pip install . --force-reinstall
+          cd $HOME
+
+          # Test the downstream package
+          pytest ${pytest_args}
+
+          # Cleanup
+          rm -rf ./test_venv

--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -1,0 +1,26 @@
+name: "Downstream Test"
+description: "Test against a downstream library"
+inputs:
+  package_name:
+    description: "The downstream package name"
+    required: true
+  package_spec:
+    description: "The package spec(s) to install, defaults to '<package_name>[test]"
+  pytest_args:
+    description: "The pytest args (defaults to '--pyargs <package_name>'"
+  env_values:
+    description: "Optional env values to set for test, e.g. 'FOO=BAR FIZZ=BUZZ'"
+runs:
+  using: "composite"
+  steps:
+    - name: set up venv
+      shell: bash
+      run: |
+          package_spec=${${{input.package_spec}}:-"${{inputs.package_name}}[test]"}
+          pytest_args=${${{input.pytest_args}}:-"--pyargs ${{inputs.package_name}}"}
+          python -m venv test
+          ./test/bin/python -m pip install -U pip
+          ./test/bin/python -m pip install ${package_spec}
+          ./test/bin/python -m pip install . --force-reinstall
+          ${{ input.env_values }} ./test/bin/pytest ${pytest_args}
+          rm -rf ./test

--- a/README.md
+++ b/README.md
@@ -62,3 +62,34 @@ jobs:
       - name: enforce-triage-label
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1
 ```
+
+## Test Downstream Library
+
+Use this action to test a package against a downstream library.  This can be used to catch breaking changes prior to merging them. An example workflow file would be:
+
+
+```yaml
+name: Downstream Tests
+on:
+  push:
+    branches: "main"
+  pull_request:
+    branches: "*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+    - name: Test Against Foo
+      uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+      with:
+        package_name: foo
+    - name: Test Against Bar
+      uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+      with:
+        package_name: bar
+        env_values: "FIZZ=buzz NAME=snuffy"
+```

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1
 ```
 
-## Test Downstream Library
+## Test Downstream Libraries
 
-Use this action to test a package against a downstream library.  This can be used to catch breaking changes prior to merging them. An example workflow file would be:
+Use this action to test a package against downstream libraries.  This can be used to catch breaking changes prior to merging them. An example workflow file would be:
 
 
 ```yaml


### PR DESCRIPTION
Fixes #20.

I decided not to use `--pre` since it pulls in prereleases of all packages, not just the one specified.

Tested in https://github.com/jupyter/jupyter_client/pull/725