### PR TITLE
Fix use of `CONTENT` in `binder-link` action

### DIFF
--- a/.github/actions/binder-link/action.yml
+++ b/.github/actions/binder-link/action.yml
@@ -26,7 +26,7 @@ runs:
             body: BODY
           };
           if ("${{ inputs.github_token }}" !== "FAKE") {
-            github.issues.createComment($CONTENT);
+            github.issues.createComment(CONTENT);
           }
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
The action would otherwise give the following error:

```
ReferenceError: $CONTENT is not defined
```