### PR TITLE
Clean up PR script workflow

### DIFF
--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -7,6 +7,10 @@ inputs:
     github_token:
       description: GitHub Access Token
       required: true
+    git_username:
+      description: The Git Username to Use for the Commit
+    git_email:
+      description: The Git Email to Use for the Commit
     script:
       description: Command(s) to run
       required: false
@@ -34,6 +38,8 @@ runs:
       env:
         GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
         MAINTAINER: ${{ github.actor }}
+        GIT_USERNAME: ${{ inputs.git_username }}
+        GIT_EMAIL: ${{ inputs.git_email }}
         TARGET: ${{ inputs.target }}
         SCRIPT: ${{ inputs.script }}
         PRE_COMMIT: ${{ inputs.pre_commit }}

--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -26,9 +26,11 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
+      shell: bash
       run: |
         pip install ghapi pre-commit
     - name: Run the script
+      shell: bash
       env:
         GITHUB_ACCESS_TOKEN: ${{ inputs.token }}
         MAINTAINER: ${{ github.actor }}

--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -7,10 +7,6 @@ inputs:
     github_token:
       description: GitHub Access Token
       required: true
-    git_username:
-      description: The Git Username to Use for the Commit
-    git_email:
-      description: The Git Email to Use for the Commit
     script:
       description: Command(s) to run
       required: false
@@ -38,8 +34,6 @@ runs:
       env:
         GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
         MAINTAINER: ${{ github.actor }}
-        GIT_USERNAME: ${{ inputs.git_username }}
-        GIT_EMAIL: ${{ inputs.git_email }}
         TARGET: ${{ inputs.target }}
         SCRIPT: ${{ inputs.script }}
         PRE_COMMIT: ${{ inputs.pre_commit }}

--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -19,8 +19,6 @@ inputs:
     commit_message:
       description: Optional commit message
       required: false
-    association:
-        description:
     dry_run:
       description: Whether this is a dry run
       required: false

--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -4,7 +4,7 @@ inputs:
     target:
       description: Target Pull Request Link
       required: true
-    token:
+    github_token:
       description: GitHub Access Token
       required: true
     script:
@@ -32,7 +32,7 @@ runs:
     - name: Run the script
       shell: bash
       env:
-        GITHUB_ACCESS_TOKEN: ${{ inputs.token }}
+        GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
         MAINTAINER: ${{ github.actor }}
         TARGET: ${{ inputs.target }}
         SCRIPT: ${{ inputs.script }}

--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -10,14 +10,19 @@ inputs:
     script:
       description: Command(s) to run
       required: false
+    association:
+      description: The Author Association for the Script
+      required: false
     pre_commit:
       description: Whether to run the pre-commit script
       required: false
     commit_message:
       description: Optional commit message
       required: false
-    script_prefix:
-      description: The prefix in the script to strip, if applicable
+    association:
+        description:
+    dry_run:
+      description: Whether this is a dry run
       required: false
 runs:
   using: "composite"
@@ -33,6 +38,7 @@ runs:
         SCRIPT: ${{ inputs.script }}
         PRE_COMMIT: ${{ inputs.pre_commit }}
         COMMIT_MESSAGE: ${{ inputs.commit_message }}
-        SCRIPT_PREFIX: ${{ inputs.script_prefix }}
+        ASSOCIATION: ${{ inputs.association }}
+        DRY_RUN: ${{ inputs.dry_run }}
       run: |
         python ${{ github.action_path }}/pr_script.py

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -70,14 +70,15 @@ def run_script():
 
     dry_run = os.environ.get("DRY_RUN", "").lower() == "true"
 
-    print("Checking for authorized user")
-    association = os.environ.get("ASSOCIATION", "COLLABORATOR")
-    if association not in ["COLLABORATOR", "MEMBER", "OWNER"]:
-        msg = f"Cannot run script for user \"{maintainer}\" with association \"{association}\""
-        if not dry_run:
-            gh.issues.create_comment(number, msg)
-        raise ValueError(msg)
-    print("User is authorized")
+    # Validate the association, unless none was given.
+    association = os.environ.get("ASSOCIATION")
+    if association:
+        if association not in ["COLLABORATOR", "MEMBER", "OWNER"]:
+            msg = f"Cannot run script for user \"{maintainer}\" with association \"{association}\""
+            if not dry_run:
+                gh.issues.create_comment(number, msg)
+            raise ValueError(msg)
+        print(f"User is authorized as {association}")
 
     # Give a confirmation message
     msg = f"Running script \"{script}\" on behalf of \"{maintainer}\""

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -92,7 +92,7 @@ def run_script():
 
     if Path("./test").exists():
         shutil.rmtree("./test")
-    url = f"https://{maintainer}:{auth}@github.com/{user_name}/{repo}"
+    url = f"https://empty:{auth}@github.com/{user_name}/{repo}"
     run(f"git clone {url} -b {branch} test")
     if dry_run:
         os.mkdir("./test")
@@ -105,11 +105,13 @@ def run_script():
         except Exception:
             continue
 
-    # Use email address for the GitHub Actions bot
+    # Use GitHub Actions bot user and email by default
     # https://github.community/t/github-actions-bot-email-address/17204/6
-    email = "41898282+github-actions[bot]@users.noreply.github.com"
+    username = os.environ.get("GIT_USERNAME", "GitHub Action")
+    bot_email = "41898282+github-actions[bot]@users.noreply.github.com"
+    email = os.environ.get("GIT_EMAIL", bot_email)
     run(f"git config user.email {email}")
-    run('git config user.name "GitHub Action"')
+    run(f"git config user.name {username}")
     message = commit_message or "Run maintainer script"
     opts = f"-m '{message}' -m 'by {maintainer}' -m '{json.dumps(script)}'"
     run(f"git commit -a {opts}")

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -106,13 +106,13 @@ def run_script():
         except Exception:
             continue
 
-    # Use GitHub Actions bot user and email.
+    # Use GitHub Actions bot user and email by default.
     # https://github.community/t/github-actions-bot-email-address/17204/6
-    username = "GitHub Action"
-    email = "41898282+github-actions[bot]@users.noreply.github.com"
-    run(f"git config user.name {username}")
+    username = os.environ.get("GIT_USERNAME", "GitHub Action")
+    bot_email = "41898282+github-actions[bot]@users.noreply.github.com"
+    email = os.environ.get("GIT_EMAIL", bot_email)
     run(f"git config user.email {email}")
-
+    run(f"git config user.name {username}")
     message = commit_message or "Run maintainer script"
     opts = f"-m '{message}' -m 'by {maintainer}' -m '{json.dumps(script)}'"
     run(f"git commit -a {opts}")

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -106,13 +106,13 @@ def run_script():
         except Exception:
             continue
 
-    # Use GitHub Actions bot user and email by default
+    # Use GitHub Actions bot user and email.
     # https://github.community/t/github-actions-bot-email-address/17204/6
-    username = os.environ.get("GIT_USERNAME", "GitHub Action")
-    bot_email = "41898282+github-actions[bot]@users.noreply.github.com"
-    email = os.environ.get("GIT_EMAIL", bot_email)
-    run(f"git config user.email {email}")
+    username = "GitHub Action"
+    email = "41898282+github-actions[bot]@users.noreply.github.com"
     run(f"git config user.name {username}")
+    run(f"git config user.email {email}")
+
     message = commit_message or "Run maintainer script"
     opts = f"-m '{message}' -m 'by {maintainer}' -m '{json.dumps(script)}'"
     run(f"git commit -a {opts}")

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -94,7 +94,7 @@ def run_script():
     if Path("./test").exists():
         shutil.rmtree("./test")
     url = f"https://empty:{auth}@github.com/{user_name}/{repo}"
-    run(f"git clone {url} -b {branch} test")
+    run(f"git clone {url} --filter=blob:none -b {branch} test")
     if dry_run:
         os.mkdir("./test")
 

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -77,9 +77,11 @@ def run_script():
         if not dry_run:
             gh.issues.create_comment(number, msg)
         raise ValueError(msg)
+    print("User is authorized")
 
     # Give a confirmation message
     msg = f"Running script \"{script}\" on behalf of \"{maintainer}\""
+    print(msg)
     if not dry_run:
         gh.issues.create_comment(number, msg)
 

--- a/.github/actions/pr-script/pr_script.py
+++ b/.github/actions/pr-script/pr_script.py
@@ -1,11 +1,11 @@
 import json
 import os
-from pathlib import Path
-import re
 import shlex
 import shutil
-from subprocess import check_output, CalledProcessError, PIPE
-import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+from subprocess import check_output
+from subprocess import PIPE
 
 from ghapi.core import GhApi
 
@@ -21,7 +21,8 @@ def run(cmd, **kwargs):
     if "/" not in parts[0]:
         executable = shutil.which(parts[0])
         if not executable:
-            raise CalledProcessError(1, f'Could not find executable "{parts[0]}"')
+            msg = f'Could not find executable "{parts[0]}"'
+            raise CalledProcessError(1, msg)
         parts[0] = executable
 
     try:
@@ -33,12 +34,21 @@ def run(cmd, **kwargs):
         raise e
 
 
-def run_script(target, script, commit_message=''):
+def run_script(target, script, commit_message=""):
     """Run a script on the target pull request URL"""
     # e.g. https://github.com/foo/bar/pull/81
-    owner, repo = target.replace("https://github.com/", "").split('/')[:2]
+    print("Checking for authorized user")
+    association = os.environ.get("ASSOCIATION", "COLLABORATOR")
+    if association not in ["COLLABORATOR", "MEMBER", "OWNER"]:
+        raise ValueError(f"Cannot run for user with association {association}")
+    print("User is authorized")
+
+    print(f"Finding owner and repo for {target}")
+    owner, repo = target.replace("https://github.com/", "").split("/")[:2]
     number = target.split("/")[-1]
-    auth = os.environ['GITHUB_ACCESS_TOKEN']
+    auth = os.environ["GITHUB_ACCESS_TOKEN"]
+
+    print(f"Extracting PR {number} from {owner}/{repo}")
     gh = GhApi(owner=owner, repo=repo, token=auth)
     # here we get the target owner and branch so we can check it out below
     pull = gh.pulls.get(number)
@@ -47,7 +57,8 @@ def run_script(target, script, commit_message=''):
 
     if Path("./test").exists():
         shutil.rmtree("./test")
-    run(f"git clone https://{maintainer}:{auth}@github.com/{user_name}/{repo} -b {branch} test")
+    url = f"https://{maintainer}:{auth}@github.com/{user_name}/{repo}"
+    run(f"git clone {url} -b {branch} test")
     os.chdir("test")
     run("pip install -e '.[test]'")
     for cmd in script:
@@ -58,32 +69,33 @@ def run_script(target, script, commit_message=''):
 
     # Use email address for the GitHub Actions bot
     # https://github.community/t/github-actions-bot-email-address/17204/6
-    run(
-        'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"'
-    )
+    email = "41898282+github-actions[bot]@users.noreply.github.com"
+    run(f"git config user.email {email}")
     run('git config user.name "GitHub Action"')
     message = commit_message or "Run maintainer script"
-    run(f"git commit -a -m  '{message}' -m 'by {maintainer}' -m '{json.dumps(script)}'")
+    opts = f"-m '{message}' -m 'by {maintainer}' -m '{json.dumps(script)}'"
+
+    run(f"git commit -a {opts}")
     run(f"git push origin {branch}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
-    target = os.environ.get('TARGET')
-    maintainer = os.environ['MAINTAINER']
-    commit_message = os.environ.get('COMMIT_MESSAGE', '')
-    script = os.environ.get('SCRIPT', '[]')
-    script_prefix = os.environ.get('SCRIPT_PREFIX', '')
-    if script:
-        script = script.replace(script_prefix, '')
+    target = os.environ.get("TARGET")
+    maintainer = os.environ["MAINTAINER"]
+    commit_message = os.environ.get("COMMIT_MESSAGE", "")
+    script = os.environ.get("SCRIPT", "[]")
+
     try:
         script = json.loads(script)
     except Exception:
         pass
+
     if not isinstance(script, list):
         script = [script]
-    if os.environ.get('PRE_COMMIT') == 'true':
-        script += ['pre-commit run --all-files']
-    print(f'Running script on {target}:')
-    print(f'   {script}')
+    if os.environ.get("PRE_COMMIT") == "true":
+        script += ["pre-commit run --all-files"]
+
+    print(f"Running script on {target}:")
+    print(f"   {script}")
     run_script(target, script, commit_message)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,13 +69,10 @@ jobs:
         commit_message: "auto run cleanup"
         target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
         association: "MEMBER"
-        git_username: "snuffy-bot"
-        git_email: "snuffy-bot@example.com"
     - name: Check PR Script Defaults
       uses: ./.github/actions/pr-script
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         dry_run: true
         pre_commit: true
-        commit_message: "auto run cleanup"
         target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,8 @@ jobs:
         commit_message: "auto run cleanup"
         target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
         association: "MEMBER"
+        git_username: "snuffy-bot"
+        git_email: "snuffy-bot@example.com"
     - name: Check PR Script Defaults
       uses: ./.github/actions/pr-script
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Check PR Script
       uses: ./.github/actions/pr-script
       with:
-        github_token: "FAKE"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         dry_run: true
         script: "[\"jlpm run integrity\", \"jlpm run lint\"]"
         commit_message: "auto run cleanup"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,20 +53,19 @@ jobs:
           github_token: "FAKE"
           url_path: "/foo/bar"
 
-
   pr_script:
-      runs-on: ubuntu-latest
-      setps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Base Setup
-        uses: ./.github/actions/base-setup
-      - name: Check Binder Link
-        uses: ./.github/actions/pr-script
-        with:
-          github_token: "FAKE"
-          dry_run: true
-          script: "[\"jlpm run integrity\", \"jlpm run lint\"]"
-          commit_message: "auto run cleanup"
-          target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
-          association: "MEMBER"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Base Setup
+      uses: ./.github/actions/base-setup
+    - name: Check Binder Link
+      uses: ./.github/actions/pr-script
+      with:
+        github_token: "FAKE"
+        dry_run: true
+        script: "[\"jlpm run integrity\", \"jlpm run lint\"]"
+        commit_message: "auto run cleanup"
+        target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
+        association: "MEMBER"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Base Setup
       uses: ./.github/actions/base-setup
-    - name: Check Binder Link
+    - name: Check PR Script
       uses: ./.github/actions/pr-script
       with:
         github_token: "FAKE"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,21 @@ jobs:
         with:
           github_token: "FAKE"
           url_path: "/foo/bar"
+
+
+  pr_script:
+      runs-on: ubuntu-latest
+      setps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Base Setup
+        uses: ./.github/actions/base-setup
+      - name: Check Binder Link
+        uses: ./.github/actions/pr-script
+        with:
+          github_token: "FAKE"
+          dry_run: true
+          script: "[\"jlpm run integrity\", \"jlpm run lint\"]"
+          commit_message: "auto run cleanup"
+          target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
+          association: "MEMBER"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Base Setup
       uses: ./.github/actions/base-setup
-    - name: Check PR Script
+    - name: Check PR Script All Options
       uses: ./.github/actions/pr-script
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,3 +69,13 @@ jobs:
         commit_message: "auto run cleanup"
         target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
         association: "MEMBER"
+        git_username: "snuffy-bot"
+        git_email: "snuffy-bot@example.com"
+    - name: Check PR Script Defaults
+      uses: ./.github/actions/pr-script
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        dry_run: true
+        pre_commit: true
+        commit_message: "auto run cleanup"
+        target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ jobs:
       - if: steps.check.outputs.triggered == 'true'
         uses: jupyterlab/maintainer-tools/.github/actions/pr-script@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pre_commit: true
           commit_message: "auto run pre-commit"
           target: ${{ github.event.issue.html_url }}
@@ -185,7 +185,7 @@ jobs:
       - if: steps.check.outputs.triggered == 'true'
         uses: jupyterlab/maintainer-tools/.github/actions/pr-script@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           script: "[\"jlpm run integrity\", \"jlpm run lint\"]"
           commit_message: "auto run cleanup"
           target:  ${{ github.event.issue.html_url }}


### PR DESCRIPTION
Follow up to #37.

After doing some [testing](https://github.com/blink1073/test-python-project/pull/3), here is what I found out:

- The `GITHUB_TOKEN` provided in the workflow is not tied to the commenter, so 
we should not allow a script to be given directly (could lead to malicious scripts),
and we should limit users by [Author Association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation).

- As mentioned in the Readme update, the resulting commit will not cause a workflow to trigger, unless
you decide to use a personal access token as the secret.  The risk of doing so is mitigated by 
limiting the script as described in the previous bullet.

- Ideally `jupyterlab-probot` should be augmented to handle this functionality, since it can push
with its own credentials, and you don't end up with a workflow run for every PR comment - Opened https://github.com/jupyterlab/jupyterlab-probot/issues/14

- This PR:
    - Adds handling of the author association
    - Adds issue comments for failure and successful start
    - Adds dry run testing
    - Improves docs on usage
    - Adds ability to set git username and email, to emulate what conda-forge does
    - Does some internal cleanup of the pr script

<img width="640" alt="image" src="https://user-images.githubusercontent.com/2096628/150658949-7e8d6375-c417-4362-a95e-cb7c1da36fbc.png">

<img width="625" alt="image" src="https://user-images.githubusercontent.com/2096628/150658956-deeed6d2-ba59-4e9c-8654-27f95283689f.png">
