### PR TITLE
Clean up usage docs for PR Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ on:
     types: [created]
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -150,6 +151,8 @@ jobs:
         id: check
         with:
           trigger: "auto run pre-commit"
+      - if: steps.check.outputs.triggered == 'true'
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - if: steps.check.outputs.triggered == 'true'
         uses: jupyterlab/maintainer-tools/.github/actions/pr-script@v1
         with:
@@ -172,6 +175,7 @@ on:
     types: [created]
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -182,6 +186,8 @@ jobs:
         id: check
         with:
           trigger: 'auto run cleanup'
+      - if: steps.check.outputs.triggered == 'true'
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - if: steps.check.outputs.triggered == 'true'
         uses: jupyterlab/maintainer-tools/.github/actions/pr-script@v1
         with:


### PR DESCRIPTION
cc @martinRenou @fcollonval we needed to add `contents: write` permission.  `pull_requests: write` allows you to affect the PR metadata and comments, not the PR content.  This was proven out in https://github.com/jupyter-server/jupyter_server/pull/686