### PR TITLE
Support starting server from Playwright config

### DIFF
--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -10,14 +10,15 @@ inputs:
   github_token:
     description: "The GitHub token to use, must have pull_request:write access"
     required: true
-  server_url:
-    description: The server URL to wait for (see https://github.com/iFaxity/wait-on-action `resource`)
-    required: true
   test_folder:
     description: The folder defining the playwright tests
     required: true
 
   # Optional inputs
+  server_url:
+    description: The server URL to wait for (see https://github.com/iFaxity/wait-on-action `resource`)
+    required: false
+    default: http-get://localhost:8888
   browser:
     description: The playwright browser to install (one of [`chromium`, `firefox`, `webkit`])
     required: false
@@ -35,7 +36,7 @@ inputs:
     required: false
     default: github-actions[bot]@users.noreply.github.com
   start_server_script:
-    description: The yarn script to execute to start the server
+    description: The yarn script to execute to start the server; set it to `null` if Playwright is handling it.
     required: false
     default: start
   update_script:
@@ -47,6 +48,7 @@ runs:
   using: composite
   steps:
     - name: Start the server
+      if: ${{ inputs.start_server_script != 'null' }}
       working-directory: ${{ inputs.test_folder }}
       shell: bash -l {0}
       run: yarn run ${{ inputs.start_server_script }} 2>&1 1>/tmp/snapshots-update-server.log &
@@ -59,6 +61,7 @@ runs:
         yarn run playwright install ${{ inputs.chromium }}
 
     - name: Wait for the server
+      if: ${{ inputs.start_server_script != 'null' }}
       uses: ifaxity/wait-on-action@v1
       with:
         resource: ${{ inputs.server_url }}
@@ -68,7 +71,6 @@ runs:
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
       run: yarn run ${{ inputs.update_script }}
-
 
     - name: Compress snapshots
       if: ${{ runner.os == 'Linux' }}
@@ -93,6 +95,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Server log
+      if: ${{ inputs.start_server_script != 'null' && always() }}
       shell: bash -l {0}
-      if: ${{ always() }}
       run: cat /tmp/snapshots-update-server.log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         pre_commit: true
         target:  "https://github.com/jupyterlab/maintainer-tools/pull/39"
 
-  update_snapshots:
+  update_snapshots-manual-server:
     runs-on: ubuntu-latest
     env:
       TEST_FOLDER: mock-playwright
@@ -121,3 +121,44 @@ jobs:
         server_url: https-get://playwright.dev
         dry_run: yes
         
+  update_snapshots:
+    runs-on: ubuntu-latest
+    env:
+      TEST_FOLDER: mock-playwright
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Base Setup
+      uses: ./.github/actions/base-setup
+    - name: Create a mock playwright test package
+      shell: bash
+      run: |
+        mkdir -p ${TEST_FOLDER}/tests/example.spec.ts-snapshots
+        pushd ${TEST_FOLDER}
+        yarn init -yp
+        yarn add -D @playwright/test
+        cat package.json | jq '. += {"scripts": {"test:update": "yarn playwright test -u"}}' > new_package.json
+        cat > tests/example.spec.ts << EOF
+        import { test, expect } from '@playwright/test';
+
+        test('basic test', async ({ page }) => {
+          await page.goto('https://playwright.dev/');
+          await page.locator('text=Get started').click();
+          await expect(page).toHaveTitle(/Getting started/);
+        });
+        EOF
+        
+        cp new_package.json package.json
+
+        # Create fake snapshot
+        touch tests/example.spec.ts-snapshots/dummy.txt
+
+        git checkout -b test-snapshot
+        popd
+    - name: Check update snapshots action
+      uses: ./.github/actions/update-snapshots
+      with:
+        github_token: "FAKE"
+        test_folder: ${{ env.TEST_FOLDER }}
+        start_server_script: "null"
+        dry_run: yes

--- a/README.md
+++ b/README.md
@@ -250,10 +250,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Test folder within your repository
           test_folder: playwright-tests
+
+          # Optional npm scripts (the default values are displayed)
+          # Script to start the server or 'null' if Playwright is taking care of it
+          #   If not `null`, you must provide a `server_url` to listen to.
+          start_server_script: start
           # Server url to wait for before updating the snapshots
           #  See specification for https://github.com/iFaxity/wait-on-action `resource`
           server_url: http-get://localhost:8888
-          # Optional npm scripts (the default values are displayed)
-          start_server_script: start
           update_script: test:update
 ```


### PR DESCRIPTION
Playwright supports starting the server from its `webServer` configuration parameter.

This adapts the update snapshots action to support that case.