### PR TITLE
Include wheel and setuptools in downstream test

### DIFF
--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -33,7 +33,7 @@ runs:
           # Set up venv
           python -m venv test_venv
           export PATH=$(pwd)/test_venv/bin:$PATH
-          python -m pip install -U pip
+          python -m pip install -U pip wheel setuptools
           cd test_venv
 
           # Download and extract the sdist


### PR DESCRIPTION
These are not included in the venv by default