### PR TITLE
Compress only new and modified versioned files

### DIFF
--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -78,7 +78,9 @@ runs:
       working-directory: ${{ inputs.test_folder }}
       run: |
         sudo apt install optipng
-        find . -wholename "*-snapshots/*.png" -exec optipng {} \;
+        # Apply compression only on new and modified versioned files
+        # - this does not filter out deleted files but it should not happen.
+        git ls-files --exclude-standard -om | grep -e "\.png" | xargs optipng
 
     - name: Commit new snapshots
       shell: bash -l {0}


### PR DESCRIPTION
In JupyterLab, the snapshots generation is split into two jobs. Triggering both broke the CI (see [logs](https://github.com/jupyterlab/jupyterlab/runs/5550326945)) because the compression tool was changing files not modified by playwright. This change the find command to a git list command to only touch modified versioned files.

> The versioned list files will include deleted files but it will not happen in the workflow as playwright will only create or update snapshots.