### PR TITLE
Do not install editable by default and dedupe constraints files

### DIFF
--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   package_spec:
     description: "The package spec to install"
-    default: "-e .\"[test]\""
+    default: ".\"[test]\""
     required: true
   test_command:
     description: "The test command"

--- a/.github/actions/install-minimums/create_constraints_file.py
+++ b/.github/actions/install-minimums/create_constraints_file.py
@@ -3,7 +3,7 @@ from pkginfo import Wheel
 from packaging.requirements import Requirement
 
 fname = sys.argv[-1]
-constraints = []
+constraints = set()
 
 # Extract the minimum versions from the requirements in the wheel.
 w = Wheel(fname)
@@ -14,7 +14,7 @@ for req in w.requires_dist:
             spec = str(specifier).replace('~', '=')
             spec = spec.replace('>=', '==')
             spec = spec.replace('>', '==')
-            constraints.append(f"{r.name}{spec}\n")
+            constraints.add(f"{r.name}{spec}\n")
 
 # Write the constraints to to a pip constraints file.
 with open('contraints_file.txt', 'w') as fid:


### PR DESCRIPTION
We shouldn't expect sdists to be installed in editable mode for downstream tests action.   They should however still be unit-testable when installed to site-packages from a local test dir.

Also a minor cleanup to prevent duplicate entries in the constraints file in the minimum version action.