### PR TITLE
Clean up default downstream test defaults

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -81,7 +81,7 @@ runs:
     - name: Upgrade packaging dependencies
       shell: bash
       run: |
-        pip install --upgrade pip setuptools wheel --user
+        pip install --upgrade pip setuptools wheel pytest-github-actions-annotate-failures --user
 
     - name: Print Diagnostics
       shell: bash

--- a/.github/actions/downstream-test/action.yml
+++ b/.github/actions/downstream-test/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   test_command:
     description: "The test command"
-    default: "pytest"
+    default: "pytest -vv -raXxs --durations 10 --color=yes"
     required: true
   extra_test:
     description: "Optional extra test to run"


### PR DESCRIPTION
Use pytest args used by ipython CI.
Also install `pytest-github-actions-annotate-failures` in the base setup function