### PR TITLE
Fix bot user names

### DIFF
--- a/.github/actions/enforce-label/action.yml
+++ b/.github/actions/enforce-label/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         script: |
           const required = ['bug', 'enhancement', 'feature', 'maintenance', 'documentation'];
-          const botUsers =['pre-commit-ci', 'dependabot'];
+          const botUsers =['pre-commit-ci[bot]', 'dependabot[bot]'];
           // https://docs.github.com/en/rest/reference/issues#get-an-issue
           const response = await github.issues.get({
             owner: context.repo.owner,


### PR DESCRIPTION
Debugged with the following code:

```python
from ghapi.all import GhApi
api = GhApi(owner='jupyterlab', repo='jupyterlab')
api.issues.get(12384).user.login
```

