### PR TITLE
Add check links action

### DIFF
--- a/.github/actions/check-links/action.yml
+++ b/.github/actions/check-links/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "Ignore links based on regex pattern(s) (space separated"
     required: false
   links_expire:
-    description: "Duration in seconds for links to be cached (default one week)",
+    description: "Duration in seconds for links to be cached (default one week)"
     required: false
 
 runs:

--- a/.github/actions/check-links/action.yml
+++ b/.github/actions/check-links/action.yml
@@ -1,0 +1,24 @@
+name: "Check Links"
+description: "Run a link check function for a repo"
+inputs:
+  ignore_glob:
+    description: "Ignore file paths based on glob pattern (space separated)"
+    required: false
+  ignore_links:
+    description: "Ignore links based on regex pattern(s) (space separated"
+    required: false
+  links_expire:
+    description: "Duration in seconds for links to be cached (default one week)",
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run the script
+      shell: bash
+      run: |
+        pip install pytest-check-links
+        export IGNORE_GLOB=${{inputs.ignore_glob}}
+        export IGNORE_LINKS=${{inputs.ignore_links}}
+        export LINKS_EXPIRE=${{inputs.links_expire}}
+        python ${{ github.action_path }}/check_links.py

--- a/.github/actions/check-links/action.yml
+++ b/.github/actions/check-links/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Run the script
       shell: bash
       run: |
-        pip install pytest-check-links
+        pip install pytest-check-links[cache]
         export IGNORE_GLOB=${{inputs.ignore_glob}}
         export IGNORE_LINKS=${{inputs.ignore_links}}
         export LINKS_EXPIRE=${{inputs.links_expire}}

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -78,5 +78,5 @@ if __name__ == "__main__":
     ignore_glob = ignore_glob.split(" ")
     ignore_links = os.environ.get("IGNORE_LINKS", "")
     ignore_links = ignore_links.split(" ")
-    links_expire = os.environ.get("LINKS_EXPIRE", "604800")
+    links_expire = os.environ.get("LINKS_EXPIRE") or "604800"
     check_links(ignore_glob, ignore_links, links_expire)

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -75,8 +75,8 @@ def check_links(ignore_glob, ignore_links, links_expire):
 
 if __name__ == "__main__":
     ignore_glob = os.environ.get("IGNORE_GLOB", "")
-    ignore_glob = ignore_glob.strip().split(" ")
+    ignore_glob = ignore_glob.strip().split(" ") if ignore_glob else []
     ignore_links = os.environ.get("IGNORE_LINKS", "")
-    ignore_links = ignore_links.strip().split(" ")
+    ignore_links = ignore_links.split(" ") if ignore_links else []
     links_expire = os.environ.get("LINKS_EXPIRE") or "604800"
     check_links(ignore_glob, ignore_links, links_expire)

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -1,10 +1,9 @@
 import os
-import os.path as osp
-import sys
-from glob import glob
-import subprocess
 import shlex
+import subprocess
+import sys
 import typing as t
+from glob import glob
 
 
 def log(*outputs, **kwargs):
@@ -74,11 +73,10 @@ def check_links(ignore_glob, ignore_links, links_expire):
         raise RuntimeError(f"Encountered failures in {fails} file(s)")
 
 
-if __name__ == '__main__':
-    ignore_glob = os.environ.get('IGNORE_GLOB', '')
-    ignore_glob = ignore_glob.split(' ')
-    ignore_links = os.environ.get('IGNORE_LINKS', '')
-    ignore_links = ignore_links.split(' ')
-    links_expire = os.environ.get('LINKS_EXPIRE', '604800')
+if __name__ == "__main__":
+    ignore_glob = os.environ.get("IGNORE_GLOB", "")
+    ignore_glob = ignore_glob.split(" ")
+    ignore_links = os.environ.get("IGNORE_LINKS", "")
+    ignore_links = ignore_links.split(" ")
+    links_expire = os.environ.get("LINKS_EXPIRE", "604800")
     check_links(ignore_glob, ignore_links, links_expire)
-

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -1,0 +1,84 @@
+import os
+import os.path as osp
+import sys
+from glob import glob
+import subprocess
+import shlex
+import typing as t
+
+
+def log(*outputs, **kwargs):
+    """Log an output to stderr"""
+    kwargs.setdefault("file", sys.stderr)
+    print(*outputs, **kwargs)
+
+
+def check_links(ignore_glob, ignore_links, links_expire):
+    """Check URLs for HTML-containing files."""
+    python = sys.executable.replace(os.sep, "/")
+    cmd = f"{python} -m pytest --noconftest --check-links --check-links-cache "
+    cmd += f"--check-links-cache-expire-after {links_expire} "
+    cmd += "-raXs --color yes --quiet "
+    # do not run doctests, since they might depend on other state.
+    cmd += "-p no:doctest "
+    # ignore package pytest configuration,
+    # since we aren't running their tests
+    cmd += "-c _IGNORE_CONFIG"
+
+    ignored = []
+    for spec in ignore_glob:
+        cmd += f' --ignore-glob "{spec}"'
+        ignored.extend(glob(spec, recursive=True))
+
+    ignore_links = list(ignore_links) + [
+        "https://github.com/.*/(pull|issues)/.*",
+        "https://github.com/search?",
+        "http://localhost.*",
+        # https://github.com/github/feedback/discussions/14773
+        "https://docs.github.com/.*",
+    ]
+
+    for spec in ignore_links:
+        cmd += f' --check-links-ignore "{spec}"'
+
+    cmd += " --ignore-glob node_modules"
+
+    # Gather all of the markdown, RST, and ipynb files
+    files: t.List[str] = []
+    for ext in [".md", ".rst", ".ipynb"]:
+        matched = glob(f"**/*{ext}", recursive=True)
+        files.extend(m for m in matched if m not in ignored and "node_modules" not in m)
+
+    log("Checking files with options:")
+    log(cmd)
+
+    fails = 0
+    separator = f"\n\n{'-' * 80}\n"
+    for f in files:
+        file_cmd = cmd + f' "{f}"'
+        file_cmd = shlex.split(file_cmd)
+        try:
+            log(f"{separator}{f}...")
+            subprocess.check_output(file_cmd, shell=False)
+        except Exception as e:
+            # Return code 5 means no tests were run (no links found)
+            if e.returncode != 5:  # type:ignore[attr-defined]
+                try:
+                    log(f"\n{f} (second attempt)...\n")
+                    subprocess.check_output(file_cmd + ["--lf"], shell=False)
+                except Exception:
+                    fails += 1
+                    if fails == 3:
+                        raise RuntimeError("Found three failed links, bailing")
+    if fails:
+        raise RuntimeError(f"Encountered failures in {fails} file(s)")
+
+
+if __name__ == '__main__':
+    ignore_glob = os.environ.get('IGNORE_GLOB', '')
+    ignore_glob = ignore_glob.split(' ')
+    ignore_links = os.environ.get('IGNORE_LINKS', '')
+    ignore_links = ignore_links.split(' ')
+    links_expire = os.environ.get('LINKS_EXPIRE', '604800')
+    check_links(ignore_glob, ignore_links, links_expire)
+

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -48,11 +48,11 @@ def check_links(ignore_glob, ignore_links, links_expire):
         matched = glob(f"**/*{ext}", recursive=True)
         files.extend(m for m in matched if m not in ignored and "node_modules" not in m)
 
-    log("Checking files with options:")
+    separator = f"\n\n{'-' * 80}\n"
+    log(f"{separator}Checking files with options:")
     log(cmd)
 
     fails = 0
-    separator = f"\n\n{'-' * 80}\n"
     for f in files:
         file_cmd = cmd + f' "{f}"'
         file_cmd = shlex.split(file_cmd)
@@ -75,8 +75,8 @@ def check_links(ignore_glob, ignore_links, links_expire):
 
 if __name__ == "__main__":
     ignore_glob = os.environ.get("IGNORE_GLOB", "")
-    ignore_glob = ignore_glob.split(" ")
+    ignore_glob = ignore_glob.strip().split(" ")
     ignore_links = os.environ.get("IGNORE_LINKS", "")
-    ignore_links = ignore_links.split(" ")
+    ignore_links = ignore_links.strip().split(" ")
     links_expire = os.environ.get("LINKS_EXPIRE") or "604800"
     check_links(ignore_glob, ignore_links, links_expire)

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -49,7 +49,7 @@ def check_links(ignore_glob, ignore_links, links_expire):
         files.extend(m for m in matched if m not in ignored and "node_modules" not in m)
 
     separator = f"\n\n{'-' * 80}\n"
-    log(f"{separator}Checking files with options:")
+    log(f"{separator}Checking files with command:")
     log(cmd)
 
     fails = 0

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -8,21 +8,13 @@ on:
 jobs:
   check_release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group: [check_release, link_check]
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Base Setup
         uses: ./.github/actions/base-setup
       - name: Check Release
-        if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: 100.100.100
-      - name: Run Link Check
-        if: ${{ matrix.group == 'link_check' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,13 @@ jobs:
           python_version: 3.7
           node_version: 15.0
 
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/base-setup
+      - uses: ./.github/actions/check-links
+
   downstream_defaults:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ and add the appropriate `--ignore-glob` and `--check-links-ignore` until the
 tests pass locally, and add them as `ignore_glob` and `ignore_links` inputs to
 the action, respectively.
 
-
 ```yaml
 name: Check Links
 
@@ -73,7 +72,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
 ```
-
 
 ## Enforce Labels
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ jobs:
         run: pytest
 ```
 
+## Check Links
+
+Use this action to check the links in your repo using `pytest-check-links`.
+It will ignore links to GitHub and cache links to save time.
+
+
+```yaml
+name: Check Links
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+```
+
+
 ## Enforce Labels
 
 Use this action to enforce one of the triage labels on PRs in your repo (one of `documentation`, `bug`, `enhancement`, `feature`, `maintenance`). An example workflow file would be:

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Use this action to check the links in your repo using `pytest-check-links`.
 It will ignore links to GitHub and cache links to save time.
 
 When adding this to a repo, you may need to skip some files or links.
-If the build fails, you can copy the pytest invocation used in the build,
-and add the appropriate `--ignore-glob` and `--check-links-ignore` until the
-tests pass locally, and add them as `ignore_glob` and `ignore_links` inputs to
-the action, respectively.
+If the build fails, you can copy the "Checking files with command" used in the
+build, and add the appropriate `--ignore-glob` and `--check-links-ignore` until
+the tests pass locally, and add them as `ignore_glob` and `ignore_links` inputs
+to the action, respectively.
 
 ```yaml
 name: Check Links

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ jobs:
 Use this action to check the links in your repo using `pytest-check-links`.
 It will ignore links to GitHub and cache links to save time.
 
+When adding this to a repo, you may need to skip some files or links.
+If the build fails, you can copy the pytest invocation used in the build,
+and add the appropriate `--ignore-glob` and `--check-links-ignore` until the
+tests pass locally, and add them as `ignore_glob` and `ignore_links` inputs to
+the action, respectively.
+
 
 ```yaml
 name: Check Links


### PR DESCRIPTION
Move the `check-links` functionality from `jupyter_releaser` here, so we can drop it from `jupyter_releaser@v2`.