### PR TITLE
Updates default minimum node version from 16 to 18

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: |
         PYTHON_VERSION="${{ inputs.python_version || matrix.python-version }}"
-        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '16.x' }}
+        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '18.x' }}
         DEPENDENCY_TYPE=${{ inputs.dependency_type }}
 
         # Handle default python value based on dependency type.


### PR DESCRIPTION
Related to https://github.com/jupyterlab/jupyterlab/pull/13722 (issue https://github.com/jupyterlab/jupyterlab/issues/13720), updates the default NodeJS version from 16.x to 18.x.