### PR TITLE
Fix `continue-on-error` configuration

### DIFF
--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -28,9 +28,9 @@ inputs:
     required: false
     default: chromium
   continue_on_error:
-    description: Whether to continue on error when updating snapshots or not.
+    description: Whether to continue on error when updating snapshots or not (one of [`yes`, `no`]).
     required: false
-    default: true
+    default: yes
   dry_run:
     description: Whether this is a dry run (one of [`yes`, `no`])
     required: false
@@ -77,7 +77,7 @@ runs:
 
     - name: Generate new snapshots
       # Get as much update as possible
-      continue-on-error: ${{ inputs.continue_on_error }}
+      continue-on-error: ${{ inputs.continue_on_error == 'yes' }}
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
       run: yarn run ${{ inputs.update_script }}


### PR DESCRIPTION
continue-on-error is not working as I forgot inputs are strings.

See error in that run: https://github.com/jupyterlab/jupyterlab/actions/runs/3940040404/jobs/6740639988

```
 Error: jupyterlab/maintainer-tools/v1/.github/actions/update-snapshots/action.yml (Line: 80, Col: 26): Unexpected value 'true'
Error: The step failed and an error occurred when attempting to determine whether to continue on error.
Error: The template is not valid. jupyterlab/maintainer-tools/v1/.github/actions/update-snapshots/action.yml (Line: 80, Col: 26): Unexpected value 'true'
```
