### PR TITLE
Add input to configure the yarn command via `npm_client`

### DIFF
--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
 
   # Optional inputs
-  yarn_cmd:
+  npm_client:
     description: The yarn command to use to execute the scripts
     required: false
     default: yarn
@@ -67,14 +67,14 @@ runs:
       if: ${{ inputs.start_server_script != 'null' }}
       working-directory: ${{ inputs.test_folder }}
       shell: bash -l {0}
-      run: (${{ inputs.yarn_cmd }} run ${{ inputs.start_server_script }} 1>/tmp/snapshots-update-server.log 2>&1) &
+      run: (${{ inputs.npm_client }} run ${{ inputs.start_server_script }} 1>/tmp/snapshots-update-server.log 2>&1) &
 
     - name: Setup integration tests
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
       run: |
-        ${{ inputs.yarn_cmd }} install
-        ${{ inputs.yarn_cmd }} run playwright install ${{ inputs.chromium }}
+        ${{ inputs.npm_client }} install
+        ${{ inputs.npm_client }} run playwright install ${{ inputs.chromium }}
 
     - name: Wait for the server
       if: ${{ inputs.start_server_script != 'null' }}
@@ -88,7 +88,7 @@ runs:
       continue-on-error: ${{ inputs.continue_on_error == 'yes' }}
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
-      run: ${{ inputs.yarn_cmd }} run ${{ inputs.update_script }}
+      run: ${{ inputs.npm_client }} run ${{ inputs.update_script }}
 
     - name: Compress snapshots
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -16,7 +16,7 @@ inputs:
 
   # Optional inputs
   npm_client:
-    description: The yarn command to use to execute the scripts
+    description: The command to execute the scripts (yarn, npm, jlpm)
     required: false
     default: yarn
   server_url:
@@ -52,11 +52,11 @@ inputs:
     required: false
     default: github-actions[bot]@users.noreply.github.com
   start_server_script:
-    description: The yarn script to execute to start the server; set it to `null` if Playwright is handling it.
+    description: The script to execute to start the server; set it to `null` if Playwright is handling it.
     required: false
     default: start
   update_script:
-    description: The yarn script to execute to update the snapshots
+    description: The script to execute to update the snapshots
     required: false
     default: test:update
 

--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -67,14 +67,14 @@ runs:
       if: ${{ inputs.start_server_script != 'null' }}
       working-directory: ${{ inputs.test_folder }}
       shell: bash -l {0}
-      run: (yarn run ${{ inputs.start_server_script }} 1>/tmp/snapshots-update-server.log 2>&1) &
+      run: (${{ inputs.yarn_cmd }} run ${{ inputs.start_server_script }} 1>/tmp/snapshots-update-server.log 2>&1) &
 
     - name: Setup integration tests
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
       run: |
-        yarn install
-        yarn run playwright install ${{ inputs.chromium }}
+        ${{ inputs.yarn_cmd }} install
+        ${{ inputs.yarn_cmd }} run playwright install ${{ inputs.chromium }}
 
     - name: Wait for the server
       if: ${{ inputs.start_server_script != 'null' }}
@@ -88,7 +88,7 @@ runs:
       continue-on-error: ${{ inputs.continue_on_error == 'yes' }}
       shell: bash -l {0}
       working-directory: ${{ inputs.test_folder }}
-      run: yarn run ${{ inputs.update_script }}
+      run: ${{ inputs.yarn_cmd }} run ${{ inputs.update_script }}
 
     - name: Compress snapshots
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/update-snapshots/action.yml
+++ b/.github/actions/update-snapshots/action.yml
@@ -15,6 +15,10 @@ inputs:
     required: true
 
   # Optional inputs
+  yarn_cmd:
+    description: The yarn command to use to execute the scripts
+    required: false
+    default: yarn
   server_url:
     description: The server URL to wait for (see https://github.com/iFaxity/wait-on-action `resource`)
     required: false

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ The requirements and constrains are:
 
 - You must be on the branch to which the snapshots will be committed
 - You must installed your project before calling the action
-- The action is using `yarn` package manager
+- The action is using `yarn` package manager by default but can be configured with `yarn_cmd`
 - The Playwright tests must be in TypeScript or JavaScript
 
 An example of workflow that get triggered when a PR comment contains

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ The requirements and constrains are:
 
 - You must be on the branch to which the snapshots will be committed
 - You must installed your project before calling the action
-- The action is using `yarn` package manager by default but can be configured with `yarn_cmd`
+- The action is using `yarn` package manager by default but can be configured with `npm_client`
 - The Playwright tests must be in TypeScript or JavaScript
 
 An example of workflow that get triggered when a PR comment contains


### PR DESCRIPTION
Add support for providing a custom yarn command for the `jupyterlab/maintainer-tools/.github/actions/update-snapshots@v1` action.

This is useful to provide a custom yarn version, or `jlpm` which has been updated to yarn 3.