### PR TITLE
Ignore links to GitHub user and organisation profiles

### DIFF
--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -35,6 +35,8 @@ def check_links(ignore_glob: list[str], ignore_links: list[str], links_expire: s
         *list(ignore_links),
         "https://github.com/.*/(pull|issues)/.*",
         "https://github.com/search?",
+        # GitHub users and organizations
+        "https://github.com/[^/]+/?$",
         "http://localhost.*",
         # https://github.com/github/feedback/discussions/14773
         "https://docs.github.com/.*",


### PR DESCRIPTION
Ignores links to GitHub user and organisation profiles (but not repositories or other pages withing GH users/organizations).

Follows discussion in https://github.com/jupyterlab/jupyterlab/issues/15776