### PR TITLE
Skip github usernames in link check

### DIFF
--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -35,6 +35,7 @@ def check_links(ignore_glob: list[str], ignore_links: list[str], links_expire: s
         *list(ignore_links),
         "https://github.com/.*/(pull|issues)/.*",
         "https://github.com/search?",
+        "https://github.com/[^/]*$",
         "http://localhost.*",
         # https://github.com/github/feedback/discussions/14773
         "https://docs.github.com/.*",


### PR DESCRIPTION
Addresses recent failures seen across libs for rate limiting https://github.com/ipython/ipykernel/actions/runs/8537763809/job/23389024807?pr=1227