### PR TITLE
Include (potentially nested) `pyproject.toml` files in the pip hash key

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -57,7 +57,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ env.CACHE_PREFIX }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.cfg', 'setup.py', '**/requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.cfg', 'setup.py', '**/requirements.txt', '**/pyproject.toml') }}
         restore-keys: |
           ${{ env.CACHE_PREFIX }}-pip-${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
Fixes #243