### PR TITLE
Enable `include-hidden-files` for `actions/upload-artifact@v4`

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -32,3 +32,4 @@ runs:
         name: ${{ steps.artifact-name.outputs.artifact_name }}
         path: ".coverage.*"
         if-no-files-found: ignore
+        include-hidden-files: true


### PR DESCRIPTION
Looks like we now need to set this option when uploading coverage, since the default file starts with a leading `.` and is likely considered as ignored.

https://github.com/actions/upload-artifact/releases/tag/v4.4.0

![image](https://github.com/user-attachments/assets/d9aa14b9-3509-4c32-9090-9c666bd32ed1)

This would explain why the coverage check started failing on notebook: https://github.com/jupyter/notebook/issues/7456