### PR TITLE
Add `include-hidden-files: true` to `report-coverage` action

### DIFF
--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -26,6 +26,7 @@ runs:
         name: coverage-data
         pattern: ${{ inputs.artifact_pattern }}
         delete-merged: true
+        include-hidden-files: true
 
     - name: Combine coverage & fail if it's <${{inputs.fail_under}}.
       shell: bash


### PR DESCRIPTION
Follow-up to #245 

Fixes https://github.com/jupyter/notebook/issues/7456
Closes https://github.com/jupyter/notebook/pull/7457

We likely need `include-hidden-files` to be set for `actions/upload-artifact/merge@v4` too.