### PR TITLE
CI: Bump pre to Python 3.13, standard to 3.12

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -21,14 +21,14 @@ runs:
 
         # Handle default python value based on dependency type.
         if [ $DEPENDENCY_TYPE == "pre" ]; then
-          DEFAULT_PYTHON="3.12"
+          DEFAULT_PYTHON="3.13"
         elif [ $DEPENDENCY_TYPE == "minimum" ]; then
           DEFAULT_PYTHON="3.8"
         elif [ $DEPENDENCY_TYPE != "standard" ]; then
           echo "Unrecognized dependency type $DEPENDENCY_TYPE"
           exit 1
         else
-          DEFAULT_PYTHON="3.11"
+          DEFAULT_PYTHON="3.12"
         fi
 
         echo "DEFAULT_PYTHON is $DEFAULT_PYTHON"

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -16,6 +16,7 @@ runs:
       with:
         # Use latest Python, so it understands all syntax.
         python-version: "3.13"
+        allow-prereleases: true
 
     - run: python -Im pip install --upgrade coverage[toml]
       shell: bash

--- a/.github/actions/report-coverage/action.yml
+++ b/.github/actions/report-coverage/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: actions/setup-python@v5
       with:
         # Use latest Python, so it understands all syntax.
-        python-version: "3.12"
+        python-version: "3.13"
 
     - run: python -Im pip install --upgrade coverage[toml]
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
         include:
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           pip install -e ".[test]"
           # NOTE: keep this version in sync with README
           python --version
-          python --version | grep "3.12"
+          python --version | grep "3.13"
           hatch run check_pre
 
   test_lint:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note: this does not work on Windows, and will error.
 If you want to use your pending dependencies, you can use the following
 option, which will create a constraints file and set the `PIP_CONSTRAINT`
 environment variable, so that installations will use that file.
-By default the Python version will be "3.12", which can be overridden with
+By default the Python version will be "3.13", which can be overridden with
 `python_version`.  Note that the environment variable also works if
 you use virtual environments like `hatch`.
 Note: this does not work on Windows, and will error.


### PR DESCRIPTION
Start testing on Python 3.13. This PR:
- Bumps the default (standard) version to Python 3.12
- Bumps the pre version to Python 3.13