### PR TITLE
Bump to `actions/github-script@v7`

### DIFF
--- a/.github/actions/binder-link/action.yml
+++ b/.github/actions/binder-link/action.yml
@@ -26,7 +26,7 @@ runs:
             body: BODY
           };
           if ("${{ inputs.github_token }}" !== "FAKE") {
-            github.issues.createComment(CONTENT);
+            github.rest.issues.createComment(CONTENT);
           }
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/actions/binder-link/action.yml
+++ b/.github/actions/binder-link/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: add binder link
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github_token }}
         script: |

--- a/.github/actions/enforce-label/action.yml
+++ b/.github/actions/enforce-label/action.yml
@@ -8,7 +8,7 @@ runs:
       if: ${{ github.event.action == 'opened' }}
       run: sleep 60
     - name: enforce-triage-label
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7
       with:
         script: |
           const required = ['bug', 'enhancement', 'feature', 'maintenance', 'documentation'];

--- a/.github/actions/enforce-label/action.yml
+++ b/.github/actions/enforce-label/action.yml
@@ -14,7 +14,7 @@ runs:
           const required = ['bug', 'enhancement', 'feature', 'maintenance', 'documentation'];
           const botUsers =['pre-commit-ci[bot]', 'dependabot[bot]'];
           // https://docs.github.com/en/rest/reference/issues#get-an-issue
-          const response = await github.issues.get({
+          const response = await github.rest.issues.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
@@ -31,7 +31,7 @@ runs:
             try {
               if (botUsers.indexOf(response.data.user.login) !== -1) {
                 // https://docs.github.com/en/rest/reference/issues#add-labels-to-an-issue
-                await github.issues.addLabels({
+                await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,


### PR DESCRIPTION
This should help fix some of these warnings, as seen on other repos using the `enforce-label` action:

![image](https://github.com/user-attachments/assets/8080b06a-75e2-4817-94d2-01f4de5a1aad)

- [ ] Handle breaking changes listed in https://github.com/actions/github-script?tab=readme-ov-file#v7