### PR TITLE
Bump min Python to 3.9;

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -23,7 +23,7 @@ runs:
         if [ $DEPENDENCY_TYPE == "pre" ]; then
           DEFAULT_PYTHON="3.13"
         elif [ $DEPENDENCY_TYPE == "minimum" ]; then
-          DEFAULT_PYTHON="3.8"
+          DEFAULT_PYTHON="3.9"
         elif [ $DEPENDENCY_TYPE != "standard" ]; then
           echo "Unrecognized dependency type $DEPENDENCY_TYPE"
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         include:
           - os: ubuntu-latest
             python-version: "3.13"
@@ -40,7 +40,7 @@ jobs:
           pip install -e ".[test]"
           # NOTE: keep the python version in sync with README
           python --version
-          python --version | grep "3.8"
+          python --version | grep "3.9"
           hatch run check_minimum
 
   base_setup_pre:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 If you want to use your minimum dependencies, you can use the following
 option, which will create a constraints file and set the `PIP_CONSTRAINT`
 environment variable, so that installations will use that file.
-By default the Python version will be "3.7", which can be overridden with
+By default the Python version will be "3.9", which can be overridden with
 `python_version`.  Note that the environment variable also works if
 you use virtual environments like `hatch`.
 Note: this does not work on Windows, and will error.


### PR DESCRIPTION
3.8 has been EOL for 2+ months.