### PR TITLE
Revert "Update default Node.js version to 24.x"

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         set -eux
         PYTHON_VERSION="${{ inputs.python_version || matrix.python-version }}"
-        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '24.x' }}
+        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '20.x' }}
         DEPENDENCY_TYPE=${{ inputs.dependency_type }}
 
         # Handle default python value based on dependency type.
@@ -62,7 +62,7 @@ runs:
           ${{ env.CACHE_PREFIX }}-pip-${{ env.PYTHON_VERSION }}
 
     - name: Install node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Base Setup
         uses: ./.github/actions/base-setup
+        with:
+          node_version: 18.0
       - name: Check Hatch Version
         run: hatch --version
 


### PR DESCRIPTION
Reverts jupyterlab/maintainer-tools#259

Reverting for now since this seems to be breaking the check release workflow when working with pre-releases:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

https://github.com/npm/cli/blob/latest/CHANGELOG.md#%EF%B8%8F-breaking-changes-1