### PR TITLE
Update default Node.js version to 24.x

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         set -eux
         PYTHON_VERSION="${{ inputs.python_version || matrix.python-version }}"
-        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '20.x' }}
+        NODE_VERSION=${{ inputs.node_version || matrix.node-version || '24.x' }}
         DEPENDENCY_TYPE=${{ inputs.dependency_type }}
 
         # Handle default python value based on dependency type.
@@ -62,7 +62,7 @@ runs:
           ${{ env.CACHE_PREFIX }}-pip-${{ env.PYTHON_VERSION }}
 
     - name: Install node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Base Setup
         uses: ./.github/actions/base-setup
-        with:
-          node_version: 18.0
       - name: Check Hatch Version
         run: hatch --version
 


### PR DESCRIPTION
New attempt.

Needs https://github.com/jupyter-server/jupyter_releaser/pull/618 to be merged and released first so the releaser handles the new npm 11 that comes with Node 24