### PR TITLE
base-setup: simplify caching and support pnpm

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -67,14 +67,21 @@ runs:
       run: |
         if [ -n "$PNPM_HASH" ]; then
           echo "manager=pnpm" >> $GITHUB_OUTPUT
+          echo "lockfile=**/pnpm-lock.yaml" >> $GITHUB_OUTPUT
         elif [ -n "$YARN_HASH" ]; then
           echo "manager=yarn" >> $GITHUB_OUTPUT
-        else
+          echo "lockfile=**/yarn.lock" >> $GITHUB_OUTPUT
+        elif [ -n "$NPM_HASH" ]; then
           echo "manager=npm" >> $GITHUB_OUTPUT
+          echo "lockfile=**/package-lock.json" >> $GITHUB_OUTPUT
+        else
+          echo "manager=" >> $GITHUB_OUTPUT
+          echo "lockfile=" >> $GITHUB_OUTPUT
         fi
       env:
         PNPM_HASH: ${{ hashFiles('**/pnpm-lock.yaml') }}
         YARN_HASH: ${{ hashFiles('**/yarn.lock') }}
+        NPM_HASH: ${{ hashFiles('**/package-lock.json') }}
 
     - name: Install pnpm
       if: steps.detect-pm.outputs.manager == 'pnpm'
@@ -94,10 +101,7 @@ runs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: ${{ steps.detect-pm.outputs.manager }}
-        cache-dependency-path: |
-          **/package-lock.json
-          **/yarn.lock
-          **/pnpm-lock.yaml
+        cache-dependency-path: ${{ steps.detect-pm.outputs.lockfile }}
 
     - name: Cache checked links
       if: ${{ matrix.group == 'link_check' }}


### PR DESCRIPTION
**Changes**

- [x] Simplify the logic used for caching based on https://github.com/actions/setup-node?tab=readme-ov-file#breaking-changes-in-v5, which was likely not available when this base-setup action was first created
- [x] Support `pnpm` to help with:
  - https://github.com/jupyterlab/jupyterlab/issues/17913
  - https://github.com/geojupyter/jupytergis/issues/1002
