### PR TITLE
Drop Python 3.9, bump versions

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -21,9 +21,9 @@ runs:
 
         # Handle default python value based on dependency type.
         if [ $DEPENDENCY_TYPE == "pre" ]; then
-          DEFAULT_PYTHON="3.13"
+          DEFAULT_PYTHON="3.15"
         elif [ $DEPENDENCY_TYPE == "minimum" ]; then
-          DEFAULT_PYTHON="3.9"
+          DEFAULT_PYTHON="3.10"
         elif [ $DEPENDENCY_TYPE != "standard" ]; then
           echo "Unrecognized dependency type $DEPENDENCY_TYPE"
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.14"]
         include:
           - os: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.15"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           pip install -e ".[test]"
           # NOTE: keep the python version in sync with README
           python --version
-          python --version | grep "3.9"
+          python --version | grep "3.10"
           hatch run check_minimum
 
   base_setup_pre:
@@ -52,7 +52,7 @@ jobs:
           pip install -e ".[test]"
           # NOTE: keep this version in sync with README
           python --version
-          python --version | grep "3.13"
+          python --version | grep "3.15"
           hatch run check_pre
 
   test_lint:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 If you want to use your minimum dependencies, you can use the following
 option, which will create a constraints file and set the `PIP_CONSTRAINT`
 environment variable, so that installations will use that file.
-By default the Python version will be "3.9", which can be overridden with
+By default the Python version will be "3.10", which can be overridden with
 `python_version`.  Note that the environment variable also works if
 you use virtual environments like `hatch`.
 Note: this does not work on Windows, and will error.
@@ -72,7 +72,7 @@ Note: this does not work on Windows, and will error.
 If you want to use your pending dependencies, you can use the following
 option, which will create a constraints file and set the `PIP_CONSTRAINT`
 environment variable, so that installations will use that file.
-By default the Python version will be "3.13", which can be overridden with
+By default the Python version will be "3.15", which can be overridden with
 `python_version`.  Note that the environment variable also works if
 you use virtual environments like `hatch`.
 Note: this does not work on Windows, and will error.


### PR DESCRIPTION
Since Python 3.9 is EOL: https://devguide.python.org/versions/#unsupported-versions