### PR TITLE
enforce-label: add 'dependencies' as an approved triage label

### DIFF
--- a/.github/actions/enforce-label/action.yml
+++ b/.github/actions/enforce-label/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
-          const required = ['bug', 'enhancement', 'feature', 'maintenance', 'documentation'];
+          const required = ['bug', 'enhancement', 'feature', 'maintenance', 'documentation', 'dependencies'];
           const botUsers =['pre-commit-ci[bot]', 'dependabot[bot]'];
           // https://docs.github.com/en/rest/reference/issues#get-an-issue
           const response = await github.rest.issues.get({


### PR DESCRIPTION
## Summary

- Adds `dependencies` to the list of approved triage labels in the `enforce-label` action.

## Motivation

Currently, when dependabot opens a PR, the action attempts to auto-assign the `maintenance` label — but this requires the workflow to have `pull-requests: write` permissions. Many repos don't grant this, causing the label check to fail.  The [default label](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#labels--) added by `dependabot` is "dependencies".