### PR TITLE
Fix syntax for `pipx install` command in base setup

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -122,9 +122,9 @@ runs:
         echo "::group::Upgrade packaging dependencies"
         python -m pip install --upgrade pip pipx
         if [ "$RUNNER_OS" != "Windows" ]; then
-          pipx install hatch>=1.16.5 --python $(which python)
+          pipx install "hatch>=1.16.5" --python $(which python)
         else
-          pipx install hatch>=1.16.5
+          pipx install "hatch>=1.16.5"
         fi
         echo "::endgroup::"
 


### PR DESCRIPTION
This fixes integrity failures due to `=1.16.5` file being created in the root.

Introduced by https://github.com/jupyterlab/maintainer-tools/pull/277