### PR TITLE
Fix `base-setup` on Python 3.9 with old cache (force pin of `virtualenv` in `hatching`)

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -202,7 +202,7 @@ runs:
           pipx install "$HATCH_SPEC"
         fi
         if [ -n "$LEGACY_VIRTUALENV_SPEC" ]; then
-          pipx inject hatch "$LEGACY_VIRTUALENV_SPEC"
+          pipx inject hatch "$LEGACY_VIRTUALENV_SPEC" --force
         fi
         echo "::endgroup::"
 


### PR DESCRIPTION
- Addresses https://github.com/jupyterlab/maintainer-tools/pull/284#discussion_r3023808112