### PR TITLE
Restore functionality to `update-snapshots-checkout` action

### DIFF
--- a/.github/actions/update-snapshots-checkout/action.yml
+++ b/.github/actions/update-snapshots-checkout/action.yml
@@ -46,7 +46,6 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ inputs.github_token }}
-        persist-credentials: false
 
     - name: Configure git to use https
       shell: bash -l {0}


### PR DESCRIPTION
Currently, users of this action will receive

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Unless they do a workaround like adding a step like this between the `update-shapshots-checkout` and `update-snapshots` steps:

```
  - name: Setup git credentials                                                                                                                                                                
    run: gh auth setup-git
    env:
      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

This isn't the case for `93556350e3433849ea434d68e8b8f7d9e9a402a4`, and I'm fairly confident that `persist-credentials: false` is why -- the credentials set up during checkout are not persisted when it comes time to push.

Maybe the `gh auth setup-git` step is the right/safe thing to do, but we'd need to document it. Or maybe we add this step to `update-snapshots` action. :shrug: 