### PR TITLE
Stop testing Python 3.9 on CI

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -193,21 +193,11 @@ runs:
         else
           python -m pip install --upgrade pip pipx
         fi
-        # For https://github.com/pypa/hatch/issues/2193 to handle older Python versions
-        if python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] <= (3, 9) else 1)'; then
-          HATCH_SPEC="hatch"
-          LEGACY_VIRTUALENV_SPEC="virtualenv<21"
-        else
-          HATCH_SPEC="hatch>=1.16.5"
-          LEGACY_VIRTUALENV_SPEC=""
-        fi
+        HATCH_SPEC="hatch>=1.16.5"
         if [ "$RUNNER_OS" != "Windows" ]; then
           pipx install "$HATCH_SPEC" --python "$(which python)"
         else
           pipx install "$HATCH_SPEC"
-        fi
-        if [ -n "$LEGACY_VIRTUALENV_SPEC" ]; then
-          pipx inject hatch "$LEGACY_VIRTUALENV_SPEC" --force
         fi
         echo "::endgroup::"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,6 @@ jobs:
         python-version: ["3.10", "3.14"]
         include:
           - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
             python-version: "3.15"
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Sir Robin", email = "robin@camelot.uk"}]
 dynamic = ["description", "version"]
 readme = "README.md"
 dependencies = ["jupyter_core>=4.12,!=5.0.*"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]


### PR DESCRIPTION
- Follow-up to #267 
- We restored 3.9 temporarily in https://github.com/jupyterlab/maintainer-tools/pull/284 to ease transition/cut some final releases with 3.9 support, but it's been half a year since it reached EOL and the cost of keeping it around is too high now IMO, see failing CI in #294 
- Reverts https://github.com/jupyterlab/maintainer-tools/pull/284