### PR TITLE
Add changed-files-only mode to check-links

### DIFF
--- a/.github/actions/check-links/action.yml
+++ b/.github/actions/check-links/action.yml
@@ -10,6 +10,10 @@ inputs:
   links_expire:
     description: "Duration in seconds for links to be cached (default one week)"
     required: false
+  changed_files_only:
+    description: "Only check links in files changed by the pull request"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -21,8 +25,11 @@ runs:
         export IGNORE_GLOB="${INPUTS_IGNORE_GLOB}"
         export IGNORE_LINKS="${INPUTS_IGNORE_LINKS}"
         export LINKS_EXPIRE=${INPUTS_LINKS_EXPIRE}
+        export CHANGED_FILES_ONLY="${INPUTS_CHANGED_FILES_ONLY}"
         python ${{ github.action_path }}/check_links.py
       env:
         INPUTS_IGNORE_GLOB: ${{inputs.ignore_glob}}
         INPUTS_IGNORE_LINKS: ${{inputs.ignore_links}}
         INPUTS_LINKS_EXPIRE: ${{inputs.links_expire}}
+        INPUTS_CHANGED_FILES_ONLY: ${{inputs.changed_files_only}}
+        PULL_REQUEST_BASE_SHA: ${{github.event.pull_request.base.sha}}

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -7,6 +7,8 @@ import sys
 import typing as t
 from glob import glob
 
+FILE_EXTENSIONS = (".md", ".rst", ".ipynb")
+
 
 def log(*outputs: str, **kwargs: t.Any) -> None:
     """Log an output to stderr"""
@@ -14,7 +16,29 @@ def log(*outputs: str, **kwargs: t.Any) -> None:
     print(*outputs, **kwargs)
 
 
-def check_links(ignore_glob: list[str], ignore_links: list[str], links_expire: str) -> None:
+def changed_files() -> list[str] | None:
+    """List changed files when running in a pull request."""
+    base_sha = os.environ.get("PULL_REQUEST_BASE_SHA")
+    if not base_sha:
+        log("No pull request base SHA found; checking all files.")
+        return None
+    subprocess.check_call(  # noqa: S603
+        ["git", "fetch", "--depth=1", "origin", base_sha],  # noqa: S607
+        stdout=subprocess.DEVNULL,
+    )
+    output = subprocess.check_output(  # noqa: S603
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", base_sha, "HEAD"],  # noqa: S607
+        text=True,
+    )
+    return output.splitlines()
+
+
+def check_links(
+    ignore_glob: list[str],
+    ignore_links: list[str],
+    links_expire: str,
+    changed_files_only: bool = False,
+) -> None:
     """Check URLs for HTML-containing files."""
     python = sys.executable.replace(os.sep, "/")
     cmd = f"{python} -m pytest --noconftest --check-links --check-links-cache "
@@ -49,9 +73,17 @@ def check_links(ignore_glob: list[str], ignore_links: list[str], links_expire: s
 
     # Gather all of the markdown, RST, and ipynb files
     files: list[str] = []
-    for ext in [".md", ".rst", ".ipynb"]:
-        matched = glob(f"**/*{ext}", recursive=True)  # noqa: PTH207
-        files.extend(m for m in matched if m not in ignored and "node_modules" not in m)
+    candidates = changed_files() if changed_files_only else None
+    if candidates is None:
+        candidates = []
+        for ext in FILE_EXTENSIONS:
+            candidates.extend(glob(f"**/*{ext}", recursive=True))  # noqa: PTH207
+
+    files.extend(
+        m
+        for m in candidates
+        if m.endswith(FILE_EXTENSIONS) and m not in ignored and "node_modules" not in m
+    )
 
     separator = f"\n\n{'-' * 80}\n"
     log(f"{separator}Checking files with command:")
@@ -87,4 +119,5 @@ if __name__ == "__main__":
     ignore_links_str = os.environ.get("IGNORE_LINKS", "")
     ignore_links = ignore_links_str.split(" ") if ignore_links_str else []
     links_expire = os.environ.get("LINKS_EXPIRE") or "604800"
-    check_links(ignore_glob, ignore_links, links_expire)
+    changed_files_only = os.environ.get("CHANGED_FILES_ONLY", "").lower() == "true"
+    check_links(ignore_glob, ignore_links, links_expire, changed_files_only)

--- a/.github/actions/check-links/check_links.py
+++ b/.github/actions/check-links/check_links.py
@@ -25,9 +25,19 @@ def changed_files() -> list[str] | None:
     subprocess.check_call(  # noqa: S603
         ["git", "fetch", "--depth=1", "origin", base_sha],  # noqa: S607
         stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
+    try:
+        merge_base = subprocess.check_output(  # noqa: S603
+            ["git", "merge-base", base_sha, "HEAD"],  # noqa: S607
+            text=True,
+        ).strip()
+        diff_base = merge_base or base_sha
+    except subprocess.CalledProcessError:
+        log("Could not determine merge-base; falling back to base SHA diff.")
+        diff_base = base_sha
     output = subprocess.check_output(  # noqa: S603
-        ["git", "diff", "--name-only", "--diff-filter=ACMRT", base_sha, "HEAD"],  # noqa: S607
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", diff_base, "HEAD"],  # noqa: S607
         text=True,
     )
     return output.splitlines()


### PR DESCRIPTION
Closes #205 

Adds an optional `changed_files_only` input to the check-links action, defaulting to false to preserve existing behavior. When enabled on pull requests, the action checks only changed `Markdown`, `reStructuredText`, and notebook files by diffing the PR base SHA against HEAD, falling back to the existing all-files behavior when no PR base SHA is available.

