### PR TITLE
Add thumbs-up reaction to PR script trigger comments

### DIFF
--- a/.github/actions/pr-script/action.yml
+++ b/.github/actions/pr-script/action.yml
@@ -33,6 +33,13 @@ runs:
       shell: bash
       run: |
         pip install ghapi pre-commit
+    - name: React to the triggering comment
+      if: github.event_name == 'issue_comment'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
     - name: Run the script
       shell: bash
       env:


### PR DESCRIPTION
Closes #201 

This adds a `issue_comment-only` acknowledgment step to the `pr-script` action, so comment-triggered maintainer requests receive a thumbs-up reaction on the triggering comment