### PR TITLE
Allow skipping node setup in base-setup

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   python_version:
     description: "The python version"
   node_version:
-    description: "The node version"
+    description: 'The node version. Set to "none" to skip installing node entirely, for projects with no JavaScript.'
   dependency_type:
     default: "standard"
     description: "The dependency installation type: standard, pre, minimum"
@@ -47,6 +47,12 @@ runs:
 
         echo "DEFAULT_PYTHON is $DEFAULT_PYTHON"
         PYTHON_VERSION="${PYTHON_VERSION:-$DEFAULT_PYTHON}"
+
+        # A node_version of "none" skips node/package manager setup altogether,
+        # for projects with no JavaScript to build or test.
+        if [ "$(echo "$NODE_VERSION" | tr '[:upper:]' '[:lower:]')" == "none" ]; then
+          NODE_VERSION="none"
+        fi
 
         echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
         echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
@@ -94,6 +100,9 @@ runs:
 
     - name: Detect package manager
       id: detect-pm
+      # Leaving the manager output empty when node is disabled also skips the
+      # pnpm install and the package manager cache steps below.
+      if: env.NODE_VERSION != 'none'
       shell: bash
       run: |
         if [ -n "$PNPM_HASH" ]; then
@@ -121,12 +130,13 @@ runs:
         version: ${{ inputs.pnpm_version }}
 
     - name: Install node
+      if: env.NODE_VERSION != 'none'
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Enable corepack
-      if: steps.detect-pm.outputs.manager != 'pnpm'
+      if: env.NODE_VERSION != 'none' && steps.detect-pm.outputs.manager != 'pnpm'
       shell: bash
       run: |
         if [ -f package.json ] && grep -q '"packageManager"' package.json; then
@@ -224,7 +234,9 @@ runs:
         pip list || true
         echo "::endgroup::"
         uv --version || true
-        node --version
-        npm --version || true
-        yarn --version || true
-        pnpm --version || true
+        if [ "$NODE_VERSION" != "none" ]; then
+          node --version
+          npm --version || true
+          yarn --version || true
+          pnpm --version || true
+        fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,22 @@ jobs:
           python --version | grep "3.10"
           hatch run check_minimum
 
+  base_setup_no_node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/base-setup
+        with:
+          node_version: "none"
+      - run: |
+          hatch --version
+          # setup-node was skipped, so any node on PATH is the one baked into
+          # the runner image rather than one from the tool cache.
+          echo "node on PATH: $(command -v node || echo '<none>')"
+          [[ "$(command -v node || true)" != *hostedtoolcache* ]]
+
   base_setup_pre:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Node is installed unconditionally, but plenty of Python-only projects have no JavaScript at all. In traitlets it costs ~6s to 20s of a 2m Windows job to install a toolchain that is never used -- the diagnostics step there just prints "pnpm: command not found". And pytest itself takes ~8 to 15 seconds. So we spend in some cases evenmore time installing node (and going through all the caching) than running the test suite.

This across many jobs will significantly speedup trailtets test timingm the other being using uv instead of pipx to install hatch but that's a PR on traitlets.

Setting node_version to "none" now skips setup-node and corepack. It also skips package manager detection, which leaves the detect-pm manager output empty and so skips the pnpm install and the package manager cache steps via their existing conditions.