### PR TITLE
Upgrade pnpm setup action to support modern `devEngines.packageManager` spec

### DIFF
--- a/.github/actions/base-setup/action.yml
+++ b/.github/actions/base-setup/action.yml
@@ -125,7 +125,7 @@ runs:
 
     - name: Install pnpm
       if: steps.detect-pm.outputs.manager == 'pnpm'
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         version: ${{ inputs.pnpm_version }}
 


### PR DESCRIPTION
The new way to specify package manager versions is `package.json` field [`devEngines.packageManager`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines). This enables version bounding instead of exact pinning of the package manager version and some other nice features. The currently-pinned version of this action doesn't support this even though `pnpm` 11 itself does, and will fail immediately if the user uses this feature instead of top-level `packageManager`.

I'd be really happy if we could release this quickly so I don't need to do a temp fix on my dependent project :) 

<details>
<summary>Error message</summary>

```
    Error: No pnpm version is specified.
    Please specify it by one of the following ways:
      - in the GitHub Action config with the key "version"
      - in the package.json with the key "packageManager"
        at readTarget (/home/runner/work/_actions/pnpm/action-setup/41ff72655975bd51cab0327fa583b6e92b6d3061/dist/index.js:1:5635)
        at runSelfInstaller (/home/runner/work/_actions/pnpm/action-setup/41ff72655975bd51cab0327fa583b6e92b6d3061/dist/index.js:1:4142)
        at async install (/home/runner/work/_actions/pnpm/action-setup/41ff72655975bd51cab0327fa583b6e92b6d3061/dist/index.js:1:3154)
        at async main (/home/runner/work/_actions/pnpm/action-setup/41ff72655975bd51cab0327fa583b6e92b6d3061/dist/index.js:1:445)
    Error: Error: No pnpm version is specified.
    Please specify it by one of the following ways:
      - in the GitHub Action config with the key "version"
      - in the package.json with the key "packageManager"
```

</details>