### PR TITLE
Bump hash pins for jupyter-releaser

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Publish changelog
         id: publish-changelog
-        uses: jupyter-server/jupyter_releaser/.github/actions/publish-changelog@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/publish-changelog@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@70e58c50c736ad496cca11fe4f2446033b68b027 # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
- Fixes https://github.com/jupyterlab/maintainer-tools/issues/305
- Same as https://github.com/jupyterlab/jupyterlab/pull/19145
- Pulls https://github.com/jupyter-server/jupyter_releaser/pull/661 from https://github.com/jupyter-server/jupyter_releaser/releases/tag/v1.11.2